### PR TITLE
Add haml_lint and rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 #
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 #
+require: rubocop-rspec
 AllCops:
   Include:
     - Rakefile

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'guard-livereload', require: false
   gem 'guard-rubocop', require: false
+  gem 'guard-shell', require: false
+
+  gem 'rubocop-rspec', require: false
+  gem 'haml_lint', require: false
 
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
     guard-rubocop (1.2.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
+    guard-shell (0.7.1)
+      guard (>= 2.0.0)
+      guard-compat (~> 1.0)
     haml (4.0.7)
       tilt
     haml-rails (0.9.0)
@@ -167,6 +170,10 @@ GEM
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    haml_lint (0.15.2)
+      haml (~> 4.0)
+      rubocop (>= 0.25.0)
+      sysexits (~> 1.1)
     hashdiff (0.2.3)
     heapy (0.1.2)
     heroku-deflater (0.6.2)
@@ -329,6 +336,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       tins (<= 1.6.0)
+    rubocop-rspec (1.3.1)
     ruby-progressbar (1.7.5)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
@@ -366,6 +374,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     stackprof (0.2.7)
+    sysexits (1.2.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     terminal-notifier-guard (1.6.4)
@@ -425,8 +434,10 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   guard-rubocop
+  guard-shell
   haml
   haml-rails
+  haml_lint
   heroku-deflater
   jbuilder
   jquery-rails
@@ -447,6 +458,7 @@ DEPENDENCIES
   rails_layout
   redcarpet
   rspec-rails
+  rubocop-rspec
   sass-rails
   sdoc
   sentry-raven

--- a/Guardfile
+++ b/Guardfile
@@ -36,6 +36,10 @@ group :spec,
     watch(%r{.+\.rb$})
     watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
   end
+
+  guard :shell do
+    watch(/.*\.haml/) { |m| `haml-lint --color #{m[0]}` }
+  end
 end
 
 guard 'livereload' do


### PR DESCRIPTION
To improve linting and code feedback when running `$ guard`