### PR TITLE
Improve bucketing algorithm

### DIFF
--- a/app/decorators/word_decorator.rb
+++ b/app/decorators/word_decorator.rb
@@ -10,7 +10,7 @@ class WordDecorator < Draper::Decorator
   end
 
   def weight
-    word.respond_to?(:rank_width_bucket) ? word.rank_width_bucket : 0
+    word.respond_to?(:weight) ? word.weight : 0
   end
 
   def searched_groups_count

--- a/app/decorators/word_decorator.rb
+++ b/app/decorators/word_decorator.rb
@@ -9,8 +9,12 @@ class WordDecorator < Draper::Decorator
     context.fetch(:is_panlexicon, false)
   end
 
-  def weighted?
-    defined? weight
+  def weight
+    word.respond_to?(:rank_width_bucket) ? word.rank_width_bucket : 0
+  end
+
+  def searched_groups_count
+    word.respond_to?(:searched_groups_count) ? word.searched_groups_count : 0
   end
 
   def in_search?
@@ -37,7 +41,7 @@ class WordDecorator < Draper::Decorator
   end
 
   def search_explanation
-    "Weight: #{word.respond_to?(:weight) ? weight : 'nil'}; Searched Groups Count: #{word.respond_to?(:searched_groups_count) ? searched_groups_count : 'nil'}; Groups Count: #{groups_count} "
+    "Weight: #{weight}; Searched Groups Count: #{searched_groups_count}; Groups Count: #{groups_count} "
   end
 
   private

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -36,7 +36,7 @@ class Search
   end
 
   def additive_groups
-    @additive_groups ||= Group.where id: additive_group_ids
+    @additive_groups ||= Group.where(id: additive_group_ids).includes(:key_word)
   end
 
   def subtractive_groups
@@ -68,7 +68,9 @@ class Search
       SELECT
         words.*,
         :searched_groups_count AS searched_groups_count,
-        :max_weight AS weight
+        :max_weight AS groups_count_width_bucket,
+        :max_weight AS rank_width_bucket,
+        :max_weight AS ntile_bucket
       FROM words
       WHERE words.id IN (:searched_word_ids)
     """
@@ -76,17 +78,52 @@ class Search
     # Selects the related words but NOT the searched words, calculating the
     # proper weight from the searched_groups_count
     select_and_weight_related_words = """
-      SELECT
+    WITH
+        grouping as (
+            SELECT word_id, COUNT(*) as searched_groups_count
+            FROM groupings
+            WHERE group_id IN (:group_ids)
+            GROUP BY word_id ORDER BY searched_groups_count DESC LIMIT :max_related_words
+        ),
+        grouping_with_rank AS (
+            SELECT
+                *,
+                DENSE_RANK() OVER (ORDER BY searched_groups_count ASC) AS dense_rank
+            FROM grouping
+        ),
+        group_stats as (
+            SELECT min(searched_groups_count) AS min_groups_count,
+                   max(searched_groups_count) AS max_groups_count,
+                   COUNT(DISTINCT(searched_groups_count)) AS count_distinct_groups,
+                   max(dense_rank) AS max_dense_rank
+            FROM grouping_with_rank
+        )
+
+    SELECT
         words.*,
-        grouping.searched_groups_count AS searched_groups_count,
-        ntile(:max_weight) OVER (ORDER BY grouping.searched_groups_count) AS weight
-      FROM (
-        SELECT word_id, COUNT(*) as searched_groups_count FROM groupings
-        WHERE group_id IN (:group_ids)
-          AND word_id NOT IN (:searched_word_ids)
-        GROUP BY word_id ORDER BY searched_groups_count DESC LIMIT :max_related_words
-      ) grouping
-      LEFT JOIN words ON words.id = grouping.word_id
+        grouping_with_rank.searched_groups_count,
+        -- grouping_with_rank.dense_rank,
+        -- group_stats.min_groups_count,
+        -- group_stats.max_groups_count,
+        -- group_stats.count_distinct_groups,
+        -- group_stats.max_dense_rank,
+        width_bucket(
+            grouping_with_rank.searched_groups_count,
+            min_groups_count - 0.001,
+            max_groups_count + 0.001,
+            :max_weight
+        ) AS groups_count_width_bucket,
+        width_bucket(
+            grouping_with_rank.dense_rank,
+            0.999,
+            group_stats.max_dense_rank + 0.001,
+            :max_weight
+        ) AS rank_width_bucket,
+        ntile(:max_weight) OVER (ORDER BY grouping_with_rank.searched_groups_count) AS ntile_bucket
+      FROM
+        grouping_with_rank LEFT JOIN words ON words.id = grouping_with_rank.word_id,
+        group_stats
+      ORDER BY name ASC
     """
 
     # Union the two select statements and fetch a collection of words


### PR DESCRIPTION
There are 3 different options it seems like for bucketing:

1. `ntile(:max_weight) OVER (ORDER BY grouping_with_rank.searched_groups_count) AS ntile_bucket`: this creates equal-sized buckets. This means that there is a nice diversity of sizes, but the sizes don't necessarily mean anything because equally scored words may be put into different buckets. e.g. `[1,1,1,4]` will be bucketed as `[[1, 1], [1, 4]]`

2.  Next:
  ```sql
       width_bucket(
          grouping_with_rank.dense_rank,
           0.999,
           group_stats.max_dense_rank + 0.001,
           :max_weight
       ) AS rank_width_bucket,
  ```
  This uses `width_bucket` upon the dense_rank (essentially counts up for each distinct group_count). This means that words will go into buckets based on where their rank is meaning that `[1, 10, 11, 12]` will be bucketed into `[[1, 10], [11, 12]]` 

3. Last:
  ```sql
        width_bucket(
            grouping_with_rank.searched_groups_count,
            min_groups_count - 0.001,
            max_groups_count + 0.001,
            :max_weight
        ) AS groups_count_width_bucket,
  ```
This uses `width_bucket` again, but by creating a set of buckets based on the value of the groups themselves. This means that `[1, 10, 11, 12]` would be bucketed into `[[1], [10, 11, 12]]`
